### PR TITLE
Use unlinkSync in pdf2png.js

### DIFF
--- a/lib/pdf2png.js
+++ b/lib/pdf2png.js
@@ -50,7 +50,7 @@ function getImage(callback, options, imageFilepath, resp, i){
 		var img = fs.readFileSync(imageFilepath);
 
 		// Remove temp file
-		fs.unlink(imageFilepath);
+		fs.unlinkSync(imageFilepath);
 
 		callback({ success: true, data: img, number: i });
 	});


### PR DESCRIPTION
Use unlinkSync in pdf2png.js to avoid having to implement callback. Doing this will remove node deprecation warning.